### PR TITLE
added missing metis-sim imports to selection-drift.jsx

### DIFF
--- a/src/selection-drift.jsx
+++ b/src/selection-drift.jsx
@@ -16,7 +16,10 @@ import {
   ops_stats_TimeFix,
   ops_stats_NumAl,
   ops_wrap_list,
-  p_generate_n_inds
+  p_generate_n_inds,
+  i_assign_random_sex,
+  integrated_generate_individual_with_genome,
+  integrated_create_freq_genome
 } from '@tiagoantao/metis-sim'
 
 


### PR DESCRIPTION
 Found that the selection-drift simulation was failing for lack of definitions which proved to be in the metis-sim import statments of other sim modules, so I added the following to the import statement in selection-drift.jsx, importing from @tiagoantao/methis-sim:  i_assign_random_sex,  integrated_generate_individual_with_genome,  integrated_create_freq_genome

I assume that these are the correct defs for the usage in the selection-drift sim.